### PR TITLE
v0.1.0-beta

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,6 +6,7 @@ services:
     environment:
       - TIMEZONE=America/Edmonton
       - TRACK_COLOUR=#e5d486
+      - EVENT_DETAIL=main
     build:
       context: ./f1_api_wrappers
     ports:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
     environment:
       - TIMEZONE=America/Edmonton
       - TRACK_COLOUR=#e5d486
-      - EVENT_DETAIL=main
+      - EVENT_DETAIL=main # Optional. main tracks qualis and races (inc. sprints), race tracks races. 
     build:
       context: ./f1_api_wrappers
     ports:

--- a/f1_api_wrappers/apis/constructors_cleaner.py
+++ b/f1_api_wrappers/apis/constructors_cleaner.py
@@ -12,7 +12,10 @@ router = APIRouter()
 LAST_RACE_API_URL = "http://localhost:4463/f1/next_race/"
 print(LAST_RACE_API_URL)
 
-MT = pytz.timezone("America/Edmonton")
+TZ = os.environ.get("TIMEZONE", "America/Edmonton").strip()
+if TZ not in pytz.all_timezones:
+    raise ValueError('Invalid time zone selection')
+MT = pytz.timezone(TZ)
 
 # Initialize caching
 @router.on_event("startup")

--- a/f1_api_wrappers/apis/constructors_cleaner.py
+++ b/f1_api_wrappers/apis/constructors_cleaner.py
@@ -12,7 +12,7 @@ router = APIRouter()
 LAST_RACE_API_URL = "http://localhost:4463/f1/next_race/"
 print(LAST_RACE_API_URL)
 
-TZ = os.environ.get("TIMEZONE", "America/Edmonton").strip()
+TZ = os.environ.get("TIMEZONE").strip()
 if TZ not in pytz.all_timezones:
     raise ValueError('Invalid time zone selection')
 MT = pytz.timezone(TZ)

--- a/f1_api_wrappers/apis/current_race_cleaner.py
+++ b/f1_api_wrappers/apis/current_race_cleaner.py
@@ -127,7 +127,10 @@ async def get_next_race():
     }
 
     next_event = None
-    detail_level = os.environ.get("EVENT_DETAIL").strip()
+    try:
+        detail_level = os.environ.get("EVENT_DETAIL").strip()
+    except Exception:
+        detail_level = 'main'
     for session_name, session_data in sorted_schedule:
         event_date_str = session_data.get("datetime_rfc3339")
         if not event_date_str:
@@ -138,8 +141,9 @@ async def get_next_race():
                 continue
         
         if detail_level == "race":
-            if session_name not in ('race'):
+            if session_name not in ('race', 'sprintRace'):
                 continue
+
         try:
             dt = datetime.fromisoformat(event_date_str)
             if dt > datetime.now(MT): 

--- a/f1_api_wrappers/apis/current_race_cleaner.py
+++ b/f1_api_wrappers/apis/current_race_cleaner.py
@@ -9,7 +9,7 @@ import os
 router = APIRouter()
 
 # Timezone information
-TZ = os.environ.get("TIMEZONE", "America/Edmonton").strip()
+TZ = os.environ.get("TIMEZONE").strip()
 if TZ not in pytz.all_timezones:
     raise ValueError('Invalid time zone selection')
 MT = pytz.timezone(TZ)

--- a/f1_api_wrappers/apis/drivers_cleaner.py
+++ b/f1_api_wrappers/apis/drivers_cleaner.py
@@ -13,7 +13,10 @@ router = APIRouter()
 
 LAST_RACE_API_URL = "http://localhost:4463/f1/next_race/"
 
-MT = pytz.timezone("America/Edmonton")
+TZ = os.environ.get("TIMEZONE", "America/Edmonton").strip()
+if TZ not in pytz.all_timezones:
+    raise ValueError('Invalid time zone selection')
+MT = pytz.timezone(TZ)
 
 # Initialize caching
 @router.on_event("startup")

--- a/f1_api_wrappers/apis/drivers_cleaner.py
+++ b/f1_api_wrappers/apis/drivers_cleaner.py
@@ -13,7 +13,7 @@ router = APIRouter()
 
 LAST_RACE_API_URL = "http://localhost:4463/f1/next_race/"
 
-TZ = os.environ.get("TIMEZONE", "America/Edmonton").strip()
+TZ = os.environ.get("TIMEZONE").strip()
 if TZ not in pytz.all_timezones:
     raise ValueError('Invalid time zone selection')
 MT = pytz.timezone(TZ)

--- a/f1_api_wrappers/apis/drivers_cleaner.py
+++ b/f1_api_wrappers/apis/drivers_cleaner.py
@@ -41,15 +41,13 @@ async def get_next_race_end():
 	   # Use f1_latest API to fetch race time for smart caching
             r = await client.get(LAST_RACE_API_URL)
             data = r.json()
-            race = data.get("race", [])[0]
-            schedule = race.get("schedule", {})
-            race_dt_str = schedule.get("race", {}).get("datetime_rfc3339")
+            next_event = data.get("next_event", {})
+            race_dt_str = next_event.get("datetime")
 
             if race_dt_str:
                 race_dt = datetime.fromisoformat(race_dt_str)
                 race_dt = race_dt.astimezone(MT)
-		# Refresh cache 4 hours after race start, idk when refreshes, may need adjustment
-                return race_dt + timedelta(hours=4)
+            return race_dt
         except Exception as e:
             print("Error fetching race time:", e)
             print("Used URL:", LAST_RACE_API_URL)
@@ -71,6 +69,11 @@ async def get_drivers_championship():
 
         data = response.json()
 
+
+    country_correction_map = {
+        "New Zealander": "New Zealand",
+        "Argentine": "Argentina"
+    }
     drivers = data.get("drivers_championship", [])
     results = []
     for entry in drivers:
@@ -78,6 +81,8 @@ async def get_drivers_championship():
         driver = entry.get("driver", {})
         team = entry.get("team", {})
         country = driver.get("nationality", "")
+        if country in country_correction_map:
+            country = country_correction_map[country]
         results.append({
             "surname": driver.get("surname"),
             "position": entry.get("position"),
@@ -87,14 +92,19 @@ async def get_drivers_championship():
             "flag": country_to_code(country)
         })
 
-    response_data = {"season": data.get("season"), "drivers": results}
-
     # Cache until race ends or 1 hour (in case f1/last is down or something
-    race_end = await get_next_race_end()
-    if race_end:
-        expire = int((race_end - datetime.now(MT)).total_seconds()) 
+    event_end = await get_next_race_end()
+    if event_end:
+        expire = int((event_end - datetime.now(MT)).total_seconds()) 
+        expiry_dt = event_end + timedelta(hours=4)
     else: 
         expire = 3600
+        expiry_dt = datetime.now(MT) + timedelta(hours=1)
+
+    response_data = {
+        "season": data.get("season"), 
+        "cache_expires": expiry_dt.isoformat(),
+        "drivers": results}
 
     await cache.set(cache_key, response_data, expire=expire)
     return response_data

--- a/f1_api_wrappers/apis/map/map_generator.py
+++ b/f1_api_wrappers/apis/map/map_generator.py
@@ -1,11 +1,12 @@
 import fastf1
 import numpy as np
 import svgwrite
+from svgwrite.base import Title
 import io
 import os 
 import re
 
-def generate_track_map_svg(year: int, gp: str, session_type: str = "Q") -> str:
+def generate_track_map_svg(year: int, gp: str, track: str, session_type: str = "Q") -> str:
     # Matches glance yellow
     track_color = os.environ['TRACK_COLOUR'].strip()
 
@@ -69,13 +70,16 @@ def generate_track_map_svg(year: int, gp: str, session_type: str = "Q") -> str:
     # Have to have a super thick line
     dwg.defs.add(dwg.style(f"""
         .{track_class} {{
-            fill: none;
+            fill: transparent;
             stroke: {track_color};
             stroke-width: 40;
+            title: {track};
             filter: drop-shadow(0 0 40px white), drop-shadow(0 0 70px {track_color});
         }}"""))
 
-    dwg.add(dwg.polyline(points=points, class_=track_class, fill='none'))
+    polyline = dwg.polyline(points=points, class_=track_class, fill='none')
+    polyline.elements.append(Title(track))
+    dwg.add(polyline)
     dwg.write(svg_buf)
 
     return svg_buf.getvalue()

--- a/f1_api_wrappers/apis/map/router.py
+++ b/f1_api_wrappers/apis/map/router.py
@@ -14,8 +14,10 @@ router = APIRouter()
 
 LAST_RACE_API_URL = "http://localhost:4463/f1/next_race/"
 
-MT = pytz.timezone("America/Edmonton")
-UTC = pytz.utc
+TZ = os.environ.get("TIMEZONE", "America/Edmonton").strip()
+if TZ not in pytz.all_timezones:
+    raise ValueError('Invalid time zone selection')
+MT = pytz.timezone(TZ)
 
 @router.on_event("startup")
 # Initialize caching

--- a/f1_api_wrappers/apis/map/router.py
+++ b/f1_api_wrappers/apis/map/router.py
@@ -14,7 +14,7 @@ router = APIRouter()
 
 LAST_RACE_API_URL = "http://localhost:4463/f1/next_race/"
 
-TZ = os.environ.get("TIMEZONE", "America/Edmonton").strip()
+TZ = os.environ.get("TIMEZONE").strip()
 if TZ not in pytz.all_timezones:
     raise ValueError('Invalid time zone selection')
 MT = pytz.timezone(TZ)

--- a/f1_next_race.yml
+++ b/f1_next_race.yml
@@ -13,7 +13,7 @@
         <p class="color-highlight">{{ $session.String "raceName" }}</p>
         <p class="color-primary">
           <span>
-            Race
+            {{ .JSON.String "next_event.session" }}
           </span>
           {{ $datetime := $session.String "schedule.race.datetime_rfc3339" }}
           <span


### PR DESCRIPTION
- Resolve TZ env variable change not applied to all scripts for caching logic.
- Add env variable so users can specify level of detail they want to track (races only, races + qualis, or all events).
- Update Glance widget to call what the next event is (IE, Qualifying in 2h)
- Update all caching based on next event (except for track map, which doesn't need to update after each event).
- Championships will now update with Sprints, resolving user issue. 