### PR TITLE
Fix Team Casing

### DIFF
--- a/API/API_Endpoints/drivers_cleaner.py
+++ b/API/API_Endpoints/drivers_cleaner.py
@@ -108,7 +108,7 @@ async def get_drivers_championship():
             "surname": driver.get("surname"),
             "position": entry.get("position"),
             "points": entry.get("points"),
-	        "teamId": team.get("teamId"),
+	        "teamId": format_team_name(team.get("teamId")),
             "country": country,
             "flag": country_to_code(country)
         })

--- a/API/API_Endpoints/drivers_cleaner.py
+++ b/API/API_Endpoints/drivers_cleaner.py
@@ -35,6 +35,16 @@ def country_to_code(country_name: str) -> str:
         return pycountry.countries.lookup(country_name).alpha_2.lower()
     except Exception:
         return ""
+
+def format_team_name(team_id: str) -> str:
+    if not team_id:
+        return ""
+    special = {
+        "rb": "RB"
+    }
+    if team_id in special:
+        return special[team_id]
+    return team_id.replace("_", " ").title()
     
 def make_signature(results):
     return hashlib.md5(json.dumps(results, 

--- a/Glance Widgets/Drivers Championship/f1_drivers_championship.yml
+++ b/Glance Widgets/Drivers Championship/f1_drivers_championship.yml
@@ -7,26 +7,17 @@
       {{ range $i, $v := .JSON.Array "drivers" }}
       <li class="flex items-center {{ if eq $i 0 }}color-primary{{ else if eq $i 1 }}color-highlight{{ end }}">
         <div class="grow min-width-0">
-          <span>{{ .String "position" }}. {{ .String "surname" }} <img src="https://flagcdn.com/w20/{{ .String "flag" }}.png"
+          <span>
+            {{ .String "position" }}. {{ .String "surname" }}
+            <img src="https://flagcdn.com/w20/{{ .String "flag" }}.png"
                  alt=""
                  style="width: 20px; height: 14px; object-fit: cover; vertical-align: middle"
-                 class="inline-block rounded-sm" /> </span>
-          {{ $id := .String "teamId" }}
-            <span class="size-h6">
-              ( {{- if eq $id "red_bull" -}}Red Bull
-              {{- else if eq $id "aston_martin" -}}Aston Martin
-              {{- else if eq $id "mercedes" -}}Mercedes
-              {{- else if eq $id "ferrari" -}}Ferrari
-              {{- else if eq $id "mclaren" -}}McLaren
-              {{- else if eq $id "williams" -}}Williams
-              {{- else if eq $id "alpine" -}}Alpine
-              {{- else if eq $id "haas" -}}Haas
-              {{- else if eq $id "rb" -}}RB
-              {{- else if eq $id "sauber" -}}Sauber
-              {{- else if eq $id "audi" -}}Audi
-              {{- else if eq $id "cadillac" -}}Cadillac
-              {{- else -}}{{ $id }}{{- end -}})
-            </span>
+                 class="inline-block rounded-sm" />
+          </span>
+
+          {{ if .String "teamId" }}
+            <span class="size-h6">({{ .String "teamId" }})</span>
+          {{ end }}
         </div>
         <span class="shrink-0 text-right">{{ .String "points" }}</span>
       </li>


### PR DESCRIPTION
Fix team name casing in drivers standings

- Format `teamId` in backend (e.g., "red_bull" → "Red Bull")
- Resolve casing issues where teams like "cadillac" and "audi" were not displaying correctly even after prior updates (ref: #52)
- Remove hardcoded if-else mapping from template
- Simplify template logic and ensure consistent, reliable team name formatting