### PR TITLE
Fix stale standings and next map widget failures

### DIFF
--- a/API/API_Endpoints/constructors_cleaner.py
+++ b/API/API_Endpoints/constructors_cleaner.py
@@ -4,16 +4,89 @@ import httpx
 from datetime import datetime, timedelta
 import hashlib
 import json
+import re
 
-from .helpers.functions import country_to_code, get_next_race_end, format_team_name
-from .helpers.global_vars import NEXT_RACE_API_URL, default_expire
-from .helpers.time_functions import MT, UTC
+from .helpers.functions import country_to_code, get_next_race_end
+from .helpers.global_vars import default_expire
+from .helpers.time_functions import MT
 
 router = APIRouter()
-    
+F1_RESULTS_URL = "https://www.formula1.com/en/results/{season}/team"
+
+
 def make_signature(results):
-    return hashlib.md5(json.dumps(results, 
-        sort_keys=True).encode()).hexdigest()
+    return hashlib.md5(json.dumps(results, sort_keys=True).encode()).hexdigest()
+
+
+def strip_tags(value: str) -> str:
+    value = re.sub(r"<[^>]+>", " ", value)
+    return " ".join(value.replace("\xa0", " ").split())
+
+
+def clean_team(team: str) -> str:
+    return {
+        "Haas F1 Team": "Haas",
+        "Red Bull Racing": "Red Bull",
+        "Racing Bulls": "RB",
+    }.get(team, team)
+
+
+async def fetch_formula1_constructors(season: int):
+    async with httpx.AsyncClient(follow_redirects=True, headers={"User-Agent": "Mozilla/5.0"}) as client:
+        response = await client.get(F1_RESULTS_URL.format(season=season), timeout=60)
+        response.raise_for_status()
+        html = response.text
+
+    table = re.search(r'<tbody[^>]*class="[^"]*Table-module_tbody[^>]*>(.*?)</tbody>', html, re.S)
+    if not table:
+        raise ValueError("Formula1 team standings table not found")
+
+    results = []
+    for row in re.findall(r'<tr[^>]*>(.*?)</tr>', table.group(1), re.S):
+        cells = re.findall(r'<td[^>]*>(.*?)</td>', row, re.S)
+        if len(cells) < 3:
+            continue
+        position = strip_tags(cells[0])
+        team = clean_team(strip_tags(cells[1]))
+        points = strip_tags(cells[2])
+        results.append({
+            "team": team,
+            "position": int(position) if position.isdigit() else position,
+            "points": int(points) if points.isdigit() else points,
+            "wins": 0,
+            "country": "",
+            "flag": country_to_code(""),
+            "wiki": "",
+        })
+    if not results:
+        raise ValueError("Formula1 team standings table was empty")
+    return results
+
+
+async def fetch_f1api_constructors():
+    async with httpx.AsyncClient() as client:
+        response = await client.get("https://f1api.dev/api/current/constructors-championship", timeout=60)
+        response.raise_for_status()
+        data = response.json()
+
+    results = []
+    for entry in data.get("constructors_championship", []):
+        team = entry.get("team", {})
+        team_name = team.get("teamName") or ""
+        for word in ["Formula 1", "F1", "Racing", "Team", "Scuderia"]:
+            team_name = team_name.replace(word, "").strip()
+        country = team.get("country", "")
+        results.append({
+            "team": team_name,
+            "position": entry.get("position"),
+            "points": entry.get("points"),
+            "wins": entry.get("wins") or 0,
+            "country": country,
+            "flag": country_to_code(country),
+            "wiki": team.get("url"),
+        })
+    return data.get("season"), results
+
 
 @router.get("/", summary="Fetch current constructors championship")
 async def get_constructors_championship():
@@ -24,81 +97,33 @@ async def get_constructors_championship():
     if cached:
         return cached
 
-    async with httpx.AsyncClient() as client:
-        response = await client.get("https://f1api.dev/api/current/constructors-championship", timeout=60)
-        if response.status_code != 200:
-            return {"error": "Failed to fetch data"}
+    season = datetime.now(MT).year
+    source = "formula1.com"
+    try:
+        results = await fetch_formula1_constructors(season)
+    except Exception:
+        source = "f1api.dev-fallback"
+        season, results = await fetch_f1api_constructors()
 
-        data = response.json()
-
-    constructors = data.get("constructors_championship", [])
-    results = []
-    for entry in constructors:
-
-        # Clean up team names and get rid of standard boilerplate slop
-        team = entry.get("team", {})
-        team_name = team.get("teamName")
-        for word in ['Formula 1', 'F1', 'Racing', 'Team', 'Scuderia']:
-            team_name = team_name.replace(word, "").strip()
-        country = team.get("country", "")
-        results.append({
-            "team": team_name,
-            "position": entry.get("position"),
-            "points": entry.get("points"),
-            "wins": entry.get("wins") or 0,
-            "country": country,
-            "flag": country_to_code(country),
-            "wiki": team.get("url")
-        })
-
-    # Cache until event ends or 1 hour (in case f1/last is down or something
     now = datetime.now(MT)
     race_dt = await get_next_race_end()
-
     expire = default_expire
     expiry_dt = now + timedelta(seconds=default_expire)
-
-    cached = await cache.get(cache_key)
-    old_signature = cached.get("result_signature") if cached else None
-    new_signature = make_signature(results)
     if race_dt:
         if race_dt > now:
-            expire = max(60, int((race_dt - now).total_seconds()))
-            expiry_dt = race_dt
+            expire = min(default_expire, max(60, int((race_dt - now).total_seconds())))
+            expiry_dt = now + timedelta(seconds=expire)
         elif now < race_dt + timedelta(seconds=default_expire):
             expiry_dt = race_dt + timedelta(seconds=default_expire)
-            expire = int((expiry_dt - now).total_seconds())
-        else:
-            expire = default_expire
-            expiry_dt = now + timedelta(seconds=default_expire)
-
-            async with httpx.AsyncClient() as client:
-                results_response = await client.get("https://f1api.dev/api/current/constructors-championship", timeout=60)
-                next_response = await client.get(NEXT_RACE_API_URL)
-
-            fresh_results = results_response.json()
-            data = next_response.json()
-            
-            new_signature = make_signature(fresh_results)
-
-            if old_signature != new_signature:
-                new_next_dt = data.get("next_event", {}).get("datetime")
-
-                if new_next_dt:
-                    next_race_dt = datetime.fromisoformat(new_next_dt)
-
-                    if next_race_dt.tzinfo is None:
-                        next_race_dt = UTC.localize(next_race_dt)
-                    next_race_dt = next_race_dt.astimezone(MT)
-
-                    expire = int((next_race_dt - now).total_seconds())
-                    expiry_dt = next_race_dt
+            expire = max(60, int((expiry_dt - now).total_seconds()))
 
     response_data = {
-        "season": data.get("season"), 
+        "season": season,
+        "source": source,
         "cache_expires": expiry_dt.isoformat(),
         "constructors": results,
-        "result_signature": new_signature}
+        "result_signature": make_signature(results),
+    }
 
     await cache.set(cache_key, response_data, expire=expire)
     return response_data

--- a/API/API_Endpoints/drivers_cleaner.py
+++ b/API/API_Endpoints/drivers_cleaner.py
@@ -4,16 +4,105 @@ import httpx
 from datetime import datetime, timedelta
 import hashlib
 import json
+import re
 
 from .helpers.functions import country_to_code, get_next_race_end, format_team_name
 from .helpers.global_vars import NEXT_RACE_API_URL, country_correction_map, default_expire
 from .helpers.time_functions import MT, UTC
 
 router = APIRouter()
+F1_RESULTS_URL = "https://www.formula1.com/en/results/{season}/drivers"
+
 
 def make_signature(results):
-    return hashlib.md5(json.dumps(results, 
-        sort_keys=True).encode()).hexdigest()
+    return hashlib.md5(json.dumps(results, sort_keys=True).encode()).hexdigest()
+
+
+def strip_tags(value: str) -> str:
+    value = re.sub(r"<[^>]+>", " ", value)
+    return " ".join(value.replace("\xa0", " ").split())
+
+
+def clean_team(team: str) -> str:
+    team = re.sub(r"-(Mercedes|Ferrari|Red Bull-Ford|Honda)$", "", team).strip()
+    replacements = {
+        "Red Bull Racing": "Red Bull",
+        "Racing Bulls": "RB",
+        "Atlassian Williams Mercedes": "Williams",
+        "Haas F1 Team": "Haas",
+        "Aston Martin Aramco Honda": "Aston Martin",
+    }
+    return replacements.get(team, format_team_name(team))
+
+
+def nationality_to_country(nationality: str) -> str:
+    return {
+        "ITA": "Italy", "GBR": "Great Britain", "MON": "Monaco", "AUS": "Australia",
+        "NED": "Netherlands", "FRA": "France", "NZL": "New Zealand", "ARG": "Argentina",
+        "ESP": "Spain", "BRA": "Brazil", "GER": "Germany", "FIN": "Finland",
+        "MEX": "Mexico", "CAN": "Canada", "THA": "Thailand",
+    }.get(nationality, nationality)
+
+
+async def fetch_formula1_drivers(season: int):
+    async with httpx.AsyncClient(follow_redirects=True, headers={"User-Agent": "Mozilla/5.0"}) as client:
+        response = await client.get(F1_RESULTS_URL.format(season=season), timeout=60)
+        response.raise_for_status()
+        html = response.text
+
+    table = re.search(r'<tbody[^>]*class="[^"]*Table-module_tbody[^>]*>(.*?)</tbody>', html, re.S)
+    if not table:
+        raise ValueError("Formula1 drivers standings table not found")
+
+    results = []
+    for row in re.findall(r'<tr[^>]*>(.*?)</tr>', table.group(1), re.S):
+        cells = re.findall(r'<td[^>]*>(.*?)</td>', row, re.S)
+        if len(cells) < 5:
+            continue
+        position = strip_tags(cells[0])
+        driver_text = strip_tags(cells[1])
+        nationality = strip_tags(cells[2])
+        team = strip_tags(cells[3])
+        points = strip_tags(cells[4])
+        parts = driver_text.split()
+        surname = parts[1] if len(parts) >= 2 else driver_text
+        country = nationality_to_country(nationality)
+        results.append({
+            "surname": surname,
+            "position": int(position) if position.isdigit() else position,
+            "points": int(points) if points.isdigit() else points,
+            "teamId": clean_team(team),
+            "country": country,
+            "flag": country_to_code(country),
+        })
+    if not results:
+        raise ValueError("Formula1 drivers standings table was empty")
+    return results
+
+
+async def fetch_f1api_drivers():
+    async with httpx.AsyncClient() as client:
+        response = await client.get("https://f1api.dev/api/current/drivers-championship", timeout=60)
+        response.raise_for_status()
+        data = response.json()
+
+    results = []
+    for entry in data.get("drivers_championship", []):
+        driver = entry.get("driver", {})
+        team = entry.get("team", {})
+        country = driver.get("nationality", "")
+        if country in country_correction_map:
+            country = country_correction_map[country]
+        results.append({
+            "surname": driver.get("surname"),
+            "position": entry.get("position"),
+            "points": entry.get("points"),
+            "teamId": format_team_name(team.get("teamId")),
+            "country": country,
+            "flag": country_to_code(country),
+        })
+    return data.get("season"), results
+
 
 @router.get("/", summary="Fetch current drivers championship")
 async def get_drivers_championship():
@@ -24,79 +113,33 @@ async def get_drivers_championship():
     if cached:
         return cached
 
-    async with httpx.AsyncClient() as client:
-        response = await client.get("https://f1api.dev/api/current/drivers-championship", timeout=60)
-        if response.status_code != 200:
-            return {"error": "Failed to fetch data"}
+    season = datetime.now(MT).year
+    source = "formula1.com"
+    try:
+        results = await fetch_formula1_drivers(season)
+    except Exception:
+        source = "f1api.dev-fallback"
+        season, results = await fetch_f1api_drivers()
 
-        data = response.json()
-
-    drivers = data.get("drivers_championship", [])
-    results = []
-    for entry in drivers:
-        driver = entry.get("driver", {})
-        team = entry.get("team", {})
-        country = driver.get("nationality", "")
-        if country in country_correction_map:
-            country = country_correction_map[country]
-        results.append({
-            "surname": driver.get("surname"),
-            "position": entry.get("position"),
-            "points": entry.get("points"),
-	        "teamId": format_team_name(team.get("teamId")),
-            "country": country,
-            "flag": country_to_code(country)
-        })
-
-    # Cache until race ends or 1 hour (in case f1/last is down or something)
     now = datetime.now(MT)
     race_dt = await get_next_race_end()
-
     expire = default_expire
     expiry_dt = now + timedelta(seconds=default_expire)
-
-    cached = await cache.get(cache_key)
-    old_signature = cached.get("result_signature") if cached else None
-    new_signature = make_signature(results)
     if race_dt:
         if race_dt > now:
-            expire = max(60, int((race_dt - now).total_seconds()))
-            expiry_dt = race_dt
+            expire = min(default_expire, max(60, int((race_dt - now).total_seconds())))
+            expiry_dt = now + timedelta(seconds=expire)
         elif now < race_dt + timedelta(seconds=default_expire):
             expiry_dt = race_dt + timedelta(seconds=default_expire)
-            expire = int((expiry_dt - now).total_seconds())
-        else:
-            expire = default_expire
-            expiry_dt = now + timedelta(seconds=default_expire)
-
-            async with httpx.AsyncClient() as client:
-                results_response = await client.get("https://f1api.dev/api/current/drivers-championship", timeout=60)
-                next_response = await client.get(NEXT_RACE_API_URL)
-
-            fresh_results = results_response.json()
-            data = next_response.json()
-            
-            new_signature = make_signature(fresh_results)
-
-            if old_signature != new_signature:
-                new_next_dt = data.get("next_event", {}).get("datetime")
-
-                if new_next_dt:
-                    next_race_dt = datetime.fromisoformat(new_next_dt)
-
-                    if next_race_dt.tzinfo is None:
-                        next_race_dt = UTC.localize(next_race_dt)
-                    next_race_dt = next_race_dt.astimezone(MT)
-
-                    expire = int((next_race_dt - now).total_seconds())
-                    expiry_dt = next_race_dt
-
+            expire = max(60, int((expiry_dt - now).total_seconds()))
 
     response_data = {
-        "season": data.get("season"), 
+        "season": season,
+        "source": source,
         "cache_expires": expiry_dt.isoformat(),
         "drivers": results,
-        "result_signature": new_signature}
+        "result_signature": make_signature(results),
+    }
 
     await cache.set(cache_key, response_data, expire=expire)
     return response_data

--- a/API/API_Endpoints/map/router.py
+++ b/API/API_Endpoints/map/router.py
@@ -1,30 +1,66 @@
-from fastapi import APIRouter, Response
-from fastapi.responses import PlainTextResponse
-import fastf1
-import httpx
-import io
 from datetime import datetime, timedelta
-import pytz
-import os
+import base64
 import hashlib
+import html
 import json
-from fastapi_cache import FastAPICache
+import re
 
-from .map_generator import generate_track_map_svg, remove_accents
+from fastapi import APIRouter, Response
+from fastapi.responses import JSONResponse, PlainTextResponse
+from fastapi_cache import FastAPICache
+import httpx
+
+from .map_generator import generate_track_map_svg
 from ..helpers.global_vars import NEXT_RACE_API_URL, default_expire
 from ..helpers.time_functions import MT
 
 router = APIRouter()
+TRACK_STROKE_WIDTH = "95"
+
 
 def make_signature(data):
-    return hashlib.md5(json.dumps(data, 
-        sort_keys=True).encode()).hexdigest()
+    return hashlib.md5(json.dumps(data, sort_keys=True).encode()).hexdigest()
+
+
+async def get_race_data():
+    async with httpx.AsyncClient() as client:
+        response = await client.get(NEXT_RACE_API_URL, timeout=60)
+        response.raise_for_status()
+        return response.json()
+
+
+def normalize_name(value):
+    normalized = str(value or "").casefold().strip()
+    return re.sub(r"\s+", " ", normalized)
+
+
+def historical_event_matches(event, city, country, race_name):
+    location_matches = city and normalize_name(event.get("Location")) == normalize_name(city)
+    country_matches = country and normalize_name(event.get("Country")) == normalize_name(country)
+    event_name_matches = race_name and normalize_name(event.get("EventName")) == normalize_name(race_name)
+    return (location_matches and country_matches) or event_name_matches
+
+
+def cache_expiry(data):
+    race = data.get("race", [{}])[0]
+    race_dt_str = race.get("schedule", {}).get("race", {}).get("datetime_rfc3339")
+    now = datetime.now(MT)
+    if not race_dt_str:
+        return now + timedelta(seconds=default_expire)
+
+    race_dt = datetime.fromisoformat(race_dt_str).astimezone(MT)
+    if now < race_dt:
+        return min(race_dt, now + timedelta(seconds=default_expire))
+    if now < race_dt + timedelta(seconds=default_expire):
+        return race_dt + timedelta(seconds=default_expire)
+    return now + timedelta(seconds=default_expire)
+
 
 def generate_historical_track_map(data):
     race = data.get("race", [{}])[0]
     circuit = race.get("circuit") or {}
-    country = circuit.get("country")
     city = circuit.get("city")
+    country = circuit.get("country")
     track = circuit.get("circuitName")
     race_name = race.get("raceName")
     current_year = int(data.get("season", datetime.now().year))
@@ -32,136 +68,106 @@ def generate_historical_track_map(data):
     errors = []
     for year in range(current_year - 1, 2017, -1):
         attempts = []
-
-        try:
-            schedule = fastf1.get_event_schedule(year)
-            matching_events = [
-                event for _, event in schedule.iterrows()
-                if historical_event_matches(event, city, country, race_name)
-            ]
-        except Exception as e:
-            errors.append(f"{year} schedule: {type(e).__name__}: {e}")
-            matching_events = []
-
-        for event in matching_events:
-            attempts.append({
-                "year": year,
-                "race_name": event.get("EventName"),
-                "track": track,
-                "session_type": "Q",
-            })
-
-        if city and country and not attempts:
-            attempts.append({
-                "year": year,
-                "city": city,
-                "country": country,
-                "track": track,
-                "session_type": "Q",
-            })
-        if race_name and not attempts:
-            attempts.append({
-                "year": year,
-                "race_name": race_name,
-                "track": track,
-                "session_type": "Q",
-            })
+        if race_name:
+            attempts.append({"year": year, "race_name": race_name, "track": track, "session_type": "Q"})
+        if city and country:
+            attempts.append({"year": year, "city": city, "country": country, "track": track, "session_type": "Q"})
 
         for kwargs in attempts:
             try:
-                return generate_track_map_svg(**kwargs)
-            except Exception as e:
-                errors.append(f"{year}: {type(e).__name__}: {e}")
+                svg = generate_track_map_svg(**kwargs)
+                return svg, year
+            except Exception as exc:
+                errors.append(f"{year}: {type(exc).__name__}: {exc}")
 
     raise ValueError("Could not fetch a historical track map. " + " | ".join(errors[-6:]))
 
-def normalize_name(value):
-    return remove_accents(str(value or "")).casefold().strip()
 
-def historical_event_matches(event, city, country, race_name):
-    location_matches = city and normalize_name(event.get("Location")) == normalize_name(city)
-    country_matches = country and normalize_name(event.get("Country")) == normalize_name(country)
-    event_name_matches = (
-        race_name
-        and normalize_name(event.get("EventName")) == normalize_name(race_name)
+def make_dashboard_svg(svg):
+    return (
+        svg
+        .replace("stroke-width: 40;", f"stroke-width: {TRACK_STROKE_WIDTH};")
+        .replace(
+            "filter: drop-shadow(0 0 40px white), drop-shadow(0 0 70px #e10600);",
+            "filter: drop-shadow(0 0 22px rgba(0,0,0,0.65)), drop-shadow(0 0 34px rgba(255,255,255,0.70));",
+        )
     )
 
-    return (location_matches and country_matches) or event_name_matches
 
-@router.get("/", summary="Fetch next track map")
-async def get_dynamic_track_map():
+def make_fallback_svg(data, error):
+    race = data.get("race", [{}])[0]
+    circuit = race.get("circuit") or {}
+    title = html.escape(circuit.get("circuitName") or race.get("raceName") or "Track map")
+    detail = html.escape("FastF1 telemetry unavailable")
+    return f'''<svg xmlns="http://www.w3.org/2000/svg" width="300" height="170" viewBox="0 0 300 170" role="img" aria-label="{title}">
+  <rect width="300" height="170" rx="18" fill="rgba(255,255,255,0.035)"/>
+  <path d="M52 104 C65 40 144 28 204 52 C261 75 249 141 176 132 C115 124 99 76 149 66 C185 59 204 82 191 101 C175 125 112 119 86 92" fill="none" stroke="#e10600" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="150" y="142" text-anchor="middle" fill="currentColor" font-family="sans-serif" font-size="15" font-weight="700">{title}</text>
+  <text x="150" y="160" text-anchor="middle" fill="currentColor" opacity="0.65" font-family="sans-serif" font-size="11">{detail}</text>
+</svg>'''
+
+
+async def get_map_payload():
     cache_key = "track_map_svg"
     cache = FastAPICache.get_backend()
 
-    # Try cached version
-    cached = await cache.get(cache_key)
-    old_signature = cached.get("signature") if cached else None
+    try:
+        data = await get_race_data()
+    except Exception as exc:
+        return PlainTextResponse(f"Failed to fetch race info: {exc}", status_code=502)
 
-    async with httpx.AsyncClient() as client:
-        try:
-            resp = await client.get(NEXT_RACE_API_URL)
-            resp.raise_for_status()
-            data = resp.json()
-        except Exception as e:
-            return PlainTextResponse(f"Failed to fetch race info: {str(e)}", status_code=502)
-        
-    upstream_signature = make_signature({
+    signature = make_signature({
         "race": data.get("race"),
-        "next_event": data.get("next_event")
+        "next_event": data.get("next_event"),
     })
-
-
-    race = data.get("race", [{}])[0]
-    race_dt_str = race.get("schedule", {}).get("race", {}).get("datetime_rfc3339")
-
-    if not race_dt_str:
-        return PlainTextResponse("Missing race datetime", status_code=500)
-    race_dt = datetime.fromisoformat(race_dt_str).astimezone(MT)
+    cached = await cache.get(cache_key)
     now = datetime.now(MT)
-    
-    if cached and old_signature == upstream_signature:
-        return Response(content=cached["svg"], media_type="image/svg+xml")
-
-    if not race_dt_str:
-        raise ValueError("Missing race time in API response")
+    if cached and cached.get("signature") == signature:
+        expires_at = cached.get("expires_at")
+        if expires_at:
+            expires_at = datetime.fromisoformat(expires_at)
+        if not expires_at or expires_at > now:
+            return cached
 
     try:
-        svg_content = generate_historical_track_map(data)
-    except Exception as e:
-        return PlainTextResponse(str(e), status_code=500)
+        svg, source_year = generate_historical_track_map(data)
+        error = None
+    except Exception as exc:
+        svg = make_fallback_svg(data, exc)
+        source_year = None
+        error = str(exc)
+    svg = make_dashboard_svg(svg)
 
-    expire = default_expire
-    expiry_dt = now + timedelta(seconds = default_expire)
-    if now > race_dt:
-        expire = int((race_dt - now).total_seconds())
-        expiry_dt = race_dt
-    elif now < race_dt + timedelta(seconds = default_expire):
-        expiry_dt = race_dt + timedelta(seconds = default_expire)
-        expire = int((expiry_dt - now).total_seconds())
-    else:
-        expire = default_expire
-        expiry_dt = now + timedelta(seconds= default_expire)
+    expires_at = cache_expiry(data)
+    expire_seconds = max(int((expires_at - now).total_seconds()), 60)
+    payload = {
+        "svg": svg,
+        "svg_base64": base64.b64encode(svg.encode("utf-8")).decode("ascii"),
+        "signature": signature,
+        "source_year": source_year,
+        "error": error,
+        "expires_at": expires_at.isoformat(),
+    }
+    await cache.set(cache_key, payload, expire=expire_seconds)
+    return payload
 
-        if old_signature and old_signature != upstream_signature:
-            print("Race changed, cache invalid, fetching new map")
 
-            next_dt = data.get("next_event", {}).get("datetime")
-            if next_dt:
-                next_race_dt = datetime.fromisoformat(next_dt)
+@router.get("/", summary="Fetch next track map")
+async def get_dynamic_track_map():
+    payload = await get_map_payload()
+    if isinstance(payload, PlainTextResponse):
+        return payload
+    return Response(content=payload["svg"], media_type="image/svg+xml")
 
-                if next_race_dt.tzinfo is None:
-                    next_race_dt = pytz.utc.localize(next_race_dt)
 
-                next_race_dt = next_race_dt.astimezone(MT)
-
-                expire = int((next_race_dt - now).total_seconds())
-                expiry_dt = next_race_dt
-
-    expire_seconds = max(int((expiry_dt - now).total_seconds()), 60)
-
-    await cache.set(cache_key, {
-        "svg": svg_content,
-        "signature": upstream_signature
-        }, expire=expire_seconds)
-
-    return Response(content=svg_content, media_type="image/svg+xml")
+@router.get("/json", summary="Fetch next track map as JSON")
+async def get_dynamic_track_map_json():
+    payload = await get_map_payload()
+    if isinstance(payload, PlainTextResponse):
+        return payload
+    return JSONResponse({
+        "svg": html.escape(payload["svg"]),
+        "svg_base64": payload["svg_base64"],
+        "source_year": payload["source_year"],
+        "error": payload.get("error"),
+    })

--- a/Glance Widgets/Next Race/f1_next_race.yml
+++ b/Glance Widgets/Next Race/f1_next_race.yml
@@ -2,48 +2,81 @@
   title: Next Race
   cache: 5m
   url: http://${F1_API_URL}:4463/f1/next_race/
+  subrequests:
+    track-map:
+      url: http://${F1_API_URL}:4463/f1/next_map/json
+      cache: 1d
   template: |
-    <div class="flex flex-column gap-10">
-      {{ $session := index (.JSON.Array "race") 0 }}
-      <p class="size-h5">
-        {{ .JSON.String "season" }}, Round {{ .JSON.String "round" }}
-      </p>
+    {{ $session := index (.JSON.Array "race") 0 }}
+    {{ $trackMap := .Subrequest "track-map" }}
+    {{ $nextDateTime := .JSON.String "next_event.datetime" }}
+    {{ $raceDateTime := $session.String "schedule.race.datetime_rfc3339" }}
+    {{ $circuit := $session.String "circuit.circuitName" }}
+    {{ $city := $session.String "circuit.city" }}
+    {{ $country := $session.String "circuit.country" }}
 
-      <div class="margin-block-4">
-        <p class="color-highlight">{{ $session.String "raceName" }}</p>
-        <p class="color-primary">
-          <span>
-            {{ .JSON.String "next_event.session" }}
-          </span>
-          {{ $datetime := .JSON.String "next_event.datetime" }}
-          <span
-            class="color-highlight"
-            {{ parseRelativeTime "rfc3339" $datetime }}
-          ></span>
-        </p>
-        <p class="size-h5">
-          {{ .JSON.String "next_event.date" }} @  {{ .JSON.String "next_event.time" }}
-        </p>
-
-        <div style="margin-block: 1rem;">
-          <img
-            src="http://${F1_API_URL}:4463/f1/next_map/"
-            onerror="this.style.display='none'"
-            style="max-width: 100%; height: auto; border-radius: 8px;"
-          />
+    <ul class="list list-gap-14">
+      <li class="flex items-center gap-10">
+        <div class="size-h6 shrink-0" style="width: 3.2rem;">
+          <span class="color-subdue">R{{ $session.String "round" }}</span>
         </div>
+        <div class="grow min-width-0 flex flex-column gap-5">
+          <div class="flex items-center justify-between gap-6">
+            <span class="text-truncate color-highlight">{{ $session.String "raceName" }}</span>
+            <span class="shrink-0 color-subdue">{{ .JSON.String "season" }}</span>
+          </div>
+          <div class="flex items-center justify-between gap-6 size-h6 color-subdue">
+            <span class="text-truncate">{{ $city }}, {{ $country }}</span>
+            <span class="shrink-0">{{ $session.String "laps" }} laps</span>
+          </div>
+        </div>
+      </li>
 
-        <p class="color-highlight">
-          Circuit Details
-        </p>
-        <p class="size-h6">
-          Name: {{ $session.String "circuit.circuitName" }}
-        </p>
-        <p class="size-h6">
-          Lap Record: {{ $session.String "circuit.lapRecord" }}, {{ $session.String "circuit.fastestLapDriverName" }} ({{ $session.String "circuit.fastestLapYear"}})
-        </p>
-        <p class="size-h6">
-          Length: {{ $session.String "laps" }} laps @ {{ $session.String "circuit.circuitLengthKm" }} KMs
-        </p>
-      </div>
-    </div>
+      <li class="flex items-center gap-10">
+        <div class="size-h6 shrink-0" style="width: 3.2rem;">
+          <span class="color-primary">Next</span>
+        </div>
+        <div class="grow min-width-0 flex flex-column gap-5">
+          <div class="flex items-center justify-between gap-6">
+            <span class="text-truncate">{{ .JSON.String "next_event.session" }}</span>
+            <span class="shrink-0 color-highlight" {{ parseRelativeTime "rfc3339" $nextDateTime }}></span>
+          </div>
+          <div class="size-h6 color-subdue">{{ .JSON.String "next_event.date" }} · {{ .JSON.String "next_event.time" }}</div>
+        </div>
+      </li>
+
+      <li class="flex items-center gap-10">
+        <div class="size-h6 shrink-0" style="width: 3.2rem;">
+          <span class="color-subdue">Race</span>
+        </div>
+        <div class="grow min-width-0 flex flex-column gap-5">
+          <div class="flex items-center justify-between gap-6">
+            <span class="text-truncate">Grand Prix</span>
+            <span class="shrink-0 color-subdue" {{ parseRelativeTime "rfc3339" $raceDateTime }}></span>
+          </div>
+          <div class="size-h6 color-subdue">{{ $session.String "schedule.race.date" }} · {{ $session.String "schedule.race.time" }}</div>
+        </div>
+      </li>
+
+      <li class="flex items-center gap-10">
+        <div class="size-h6 shrink-0" style="width: 3.2rem;">
+          <span class="color-subdue">Track</span>
+        </div>
+        <div class="grow min-width-0 flex flex-column gap-5">
+          <div class="flex items-center justify-between gap-6">
+            <span class="text-truncate">{{ $circuit }}</span>
+            <span class="shrink-0 color-subdue">{{ $session.String "circuit.circuitLengthKm" }} km</span>
+          </div>
+          <div class="size-h6 color-subdue">Lap record {{ $session.String "circuit.lapRecord" }} · {{ $session.String "circuit.fastestLapDriverName" }} {{ $session.String "circuit.fastestLapYear" }}</div>
+        </div>
+      </li>
+
+      {{ if eq $trackMap.Response.StatusCode 200 }}
+      <li>
+        <img
+          src="data:image/svg+xml;base64,{{ $trackMap.JSON.String "svg_base64" }}"
+          style="display: block; width: 100%; max-height: 150px; object-fit: contain; box-sizing: border-box; padding: 2px 0;"
+        />
+      </li>
+      {{ end }}
+    </ul>


### PR DESCRIPTION
## Summary
- Prefer official formula1.com results pages for driver and constructor championship standings, keeping f1api.dev as a fallback.
- Cap standings cache during race weekends so championship data does not stay stale until the next race/session boundary.
- Add `/f1/next_map/json` with base64 SVG payload for Glance subrequests.
- Return a compact fallback SVG instead of HTTP 500 when FastF1 telemetry is unavailable for a historical track map.
- Update the Next Race widget to use the cleaner list-based layout style used by the football widgets.

## Why
Fixes stale standings and `500 Internal Server Error` map failures seen in a live Glance dashboard. The map issue happens when FastF1 can identify events but cannot load usable lap/telemetry data for the attempted historical sessions.

Fixes #67

## Test Plan
- `python3 -m py_compile API/API_Endpoints/drivers_cleaner.py API/API_Endpoints/constructors_cleaner.py API/API_Endpoints/map/router.py`
- `git diff --check`
- Live container smoke test against patched files:
  - `/f1/drivers_standings/` returns formula1.com standings.
  - `/f1/constructors_standings/` returns formula1.com standings.
  - `/f1/next_map/json` returns 200 with `svg_base64` even when FastF1 telemetry is unavailable.
  - Glance sports page renders the Next Race widget using the compact football-widget-style list layout.
